### PR TITLE
Add CSV preview helper

### DIFF
--- a/AdaptaBrasilAPIAccess.py
+++ b/AdaptaBrasilAPIAccess.py
@@ -35,7 +35,7 @@ def cleanhtml(raw_html):
 
 if __name__ == '__main__':
     args = get_command_line_arguments()
-        url_hierarchy = f"{args.base_url}{'' if args.base_url[-1] == '/' else '/'}api/hierarquia/{args.schema}"
+    url_hierarchy = f"{args.base_url}{'' if args.base_url[-1] == '/' else '/'}api/hierarquia/{args.schema}"
     with urllib.request.urlopen(url_hierarchy) as url, open(args.arquivo_saida,mode='w', encoding='utf-8') as csv_file:
         indicators = json.load(url)
         s = '\ufeff' # BOM code to preserve diacritics em Excel

--- a/print_csv_preview.py
+++ b/print_csv_preview.py
@@ -1,0 +1,18 @@
+import csv
+import argparse
+
+parser = argparse.ArgumentParser(description='Mostra as primeiras linhas do CSV gerado pelo AdaptaBrasilAPIAccess.')
+parser.add_argument('arquivo', help='Arquivo CSV a ser exibido')
+parser.add_argument('-n', '--num-linhas', type=int, default=5, help='Número de linhas a serem exibidas')
+
+args = parser.parse_args()
+
+with open(args.arquivo, encoding='utf-8') as f:
+    reader = csv.DictReader(f, delimiter='|')
+    for i, row in enumerate(reader, start=1):
+        print(f'Linha {i}:')
+        for campo, valor in row.items():
+            print(f'  {campo}: {valor}')
+        print()
+        if i >= args.num_linhas:
+            break


### PR DESCRIPTION
## Summary
- fix indentation error in `AdaptaBrasilAPIAccess.py`
- add `print_csv_preview.py` helper to display the first lines of a generated CSV

## Testing
- `python print_csv_preview.py adaptaBrasilAPIEstrutura.csv -n 1`

------
https://chatgpt.com/codex/tasks/task_e_685aa1bf32008321842ad1e5971eedd6